### PR TITLE
Disable gamemode vote for players

### DIFF
--- a/config/config.txt
+++ b/config/config.txt
@@ -165,7 +165,7 @@ ID_CONSOLE_JOBSLOT_DELAY 30
 ALLOW_VOTE_RESTART
 
 ## allow players to initiate a mode-change vote
-ALLOW_VOTE_MODE
+#ALLOW_VOTE_MODE
 
 ## allow players to initiate a map-change vote
 ALLOW_VOTE_MAP


### PR DESCRIPTION
Forces the server to restart. Restarts are being abused to reroll for antag and killing the server.