### PR TITLE
Increase space ruin spawn count

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -527,7 +527,7 @@ BOMBCAP 20
 LAVALAND_BUDGET 60
 
 ## Space Ruin Budged
-Space_Budget 16
+Space_Budget 35
 
 ## Time in ds from when a player latejoins till the arrival shuttle docks at the station
 ## Must be at least 30. At least 55 recommended to be visually/aurally appropriate


### PR DESCRIPTION
Would help with more spawners spawning. I almost never see the syndicate listening base spawn for example. Also there isn't much of an advantage to keeping it low since space ruin loot isn't as good as lavaland loot. Maybe increase it to 30-40 (lavaland is 60 for reference). I don't see any harm with jacking the number way up.