### PR TITLE
Sets default client FPS to 60

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -89,7 +89,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 	var/list/ignoring = list()
 
-	var/clientfps = 0
+	var/clientfps = 60
 
 	var/parallax
 


### PR DESCRIPTION
## About The Pull Request
Sets default save file FPS to 60, new clients only affected

## Why It's Good For The Game
Good for preventing new players from spawning in and being immediately turned off from the game.

## Changelog
:cl:
tweak: Default FPS changed from 0 to 60
/:cl: